### PR TITLE
Fix Layout regex

### DIFF
--- a/allo/memory.py
+++ b/allo/memory.py
@@ -9,7 +9,7 @@ class Layout:
     def __init__(self, placement):
         # R: replicated, S: shared
         # e.g., S0S1R, S0R, RS0
-        pattern = r"([A-Z])(\d)?"
+        pattern = r"([A-Z])(\d*)"
         matches = re.findall(pattern, placement)
         result = []
         for letter, number in matches:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,6 @@
+from allo.memory import Layout
+
+
+def test_layout_multi_digit():
+    layout = Layout("S10R")
+    assert layout.placement == [("S", 10), ("R", None)]


### PR DESCRIPTION
## Summary
- support multiple-digit dimension numbers in Layout parsing
- add a test for Layout parsing

## Testing
- `python3 -m py_compile allo/memory.py tests/test_layout.py`