### PR TITLE
Fix Layout validation

### DIFF
--- a/allo/memory.py
+++ b/allo/memory.py
@@ -9,13 +9,22 @@ class Layout:
     def __init__(self, placement):
         # R: replicated, S: shared
         # e.g., S0S1R, S0R, RS0
-        pattern = r"([A-Z])(\d)?"
+        pattern = r"([A-Z])(\d*)"
         matches = re.findall(pattern, placement)
+        if not matches or "".join(l + n for l, n in matches) != placement:
+            raise ValueError(f"Invalid layout string: {placement}")
+
         result = []
         for letter, number in matches:
-            if number:
+            if letter not in ("R", "S"):
+                raise ValueError(f"Unknown layout opcode `{letter}`")
+            if letter == "S":
+                if not number:
+                    raise ValueError("`S` must be followed by a dimension index")
                 result.append((letter, int(number)))
-            else:
+            else:  # letter == "R"
+                if number:
+                    raise ValueError("`R` should not have a dimension index")
                 result.append((letter, None))
         self.placement = result
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,25 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from allo.memory import Layout
+
+
+def test_layout_multi_digit():
+    layout = Layout("S10R")
+    assert layout.placement == [("S", 10), ("R", None)]
+
+
+def test_layout_missing_dimension():
+    with pytest.raises(ValueError):
+        Layout("SR")
+
+
+def test_layout_invalid_letter():
+    with pytest.raises(ValueError):
+        Layout("X0")
+
+
+def test_layout_unexpected_index():
+    with pytest.raises(ValueError):
+        Layout("R0")


### PR DESCRIPTION
## Summary
- validate layout strings in `Layout.__init__`
- expand tests for invalid layout formats

## Testing
- `python3 -m py_compile allo/memory.py tests/test_layout.py`
- `python3 scripts/lint/check_license_header.py HEAD~1`
- `bash scripts/lint/git-black.sh HEAD~1`
- `bash scripts/lint/git-clang-format.sh HEAD~1`
- `python3 -m pylint allo --rcfile=./scripts/lint/pylintrc` *(fails: No module named `pylint`)*